### PR TITLE
메모리에 기반한 Global Translation Directory 제작 완료에 따른 병합 요청건

### DIFF
--- a/drivers/lightnvm/Makefile
+++ b/drivers/lightnvm/Makefile
@@ -8,4 +8,4 @@ obj-$(CONFIG_NVM_PBLK)		+= pblk.o
 pblk-y				:= pblk-init.o pblk-core.o pblk-rb.o \
 				   pblk-write.o pblk-cache.o pblk-read.o \
 				   pblk-gc.o pblk-recovery.o pblk-map.o \
-				   pblk-rl.o pblk-sysfs.o
+				   pblk-rl.o pblk-sysfs.o pblk-trans.o

--- a/drivers/lightnvm/pblk-core.c
+++ b/drivers/lightnvm/pblk-core.c
@@ -778,8 +778,6 @@ u64 pblk_line_smeta_start(struct pblk *pblk, struct pblk_line *line)
 	if (bit >= lm->blk_per_line)
 		return -1;
 
-	// Gijun: ws_opt is optimal write size
-	// This just traverse the write position
 	return bit * geo->ws_opt;
 }
 

--- a/drivers/lightnvm/pblk-core.c
+++ b/drivers/lightnvm/pblk-core.c
@@ -778,6 +778,8 @@ u64 pblk_line_smeta_start(struct pblk *pblk, struct pblk_line *line)
 	if (bit >= lm->blk_per_line)
 		return -1;
 
+	// Gijun: ws_opt is optimal write size
+	// This just traverse the write position
 	return bit * geo->ws_opt;
 }
 
@@ -805,6 +807,7 @@ static int pblk_line_submit_smeta_io(struct pblk *pblk, struct pblk_line *line,
 	} else
 		return -EINVAL;
 
+	// nvme request
 	memset(&rqd, 0, sizeof(struct nvm_rq));
 
 	rqd.meta_list = nvm_dev_dma_alloc(dev->parent, GFP_KERNEL,
@@ -816,7 +819,6 @@ static int pblk_line_submit_smeta_io(struct pblk *pblk, struct pblk_line *line,
 	rqd.dma_ppa_list = rqd.dma_meta_list + pblk_dma_meta_size;
 
 	bio = bio_map_kern(dev->q, line->smeta, lm->smeta_len, GFP_KERNEL);
-	if (IS_ERR(bio)) {
 		ret = PTR_ERR(bio);
 		goto free_ppa_list;
 	}

--- a/drivers/lightnvm/pblk-core.c
+++ b/drivers/lightnvm/pblk-core.c
@@ -819,6 +819,7 @@ static int pblk_line_submit_smeta_io(struct pblk *pblk, struct pblk_line *line,
 	rqd.dma_ppa_list = rqd.dma_meta_list + pblk_dma_meta_size;
 
 	bio = bio_map_kern(dev->q, line->smeta, lm->smeta_len, GFP_KERNEL);
+	if (IS_ERR(bio)) {
 		ret = PTR_ERR(bio);
 		goto free_ppa_list;
 	}

--- a/drivers/lightnvm/pblk-init.c
+++ b/drivers/lightnvm/pblk-init.c
@@ -1238,6 +1238,12 @@ static void *pblk_init(struct nvm_tgt_dev *dev, struct gendisk *tdisk,
 		goto fail_stop_writer;
 	}
 
+	ret = pblk_trans_init(pblk);
+	if (ret) {
+		pr_err("pblk: could not initialize translation directory\n");
+		goto fail_free_trans;
+	}
+
 	/* inherit the size from the underlying device */
 	blk_queue_logical_block_size(tqueue, queue_physical_block_size(bqueue));
 	blk_queue_max_hw_sectors(tqueue, queue_max_hw_sectors(bqueue));
@@ -1262,6 +1268,8 @@ static void *pblk_init(struct nvm_tgt_dev *dev, struct gendisk *tdisk,
 
 	return pblk;
 
+fail_free_trans:
+	pblk_trans_init(pblk);
 fail_stop_writer:
 	pblk_writer_stop(pblk);
 fail_free_l2p:
@@ -1316,5 +1324,6 @@ module_init(pblk_module_init);
 module_exit(pblk_module_exit);
 MODULE_AUTHOR("Javier Gonzalez <javier@cnexlabs.com>");
 MODULE_AUTHOR("Matias Bjorling <matias@cnexlabs.com>");
+MODULE_AUTHOR("O Gijun <kijunking@pusan.ac.kr>");
 MODULE_LICENSE("GPL v2");
 MODULE_DESCRIPTION("Physical Block-Device for Open-Channel SSDs");

--- a/drivers/lightnvm/pblk-init.c
+++ b/drivers/lightnvm/pblk-init.c
@@ -100,8 +100,9 @@ static u32 pblk_l2p_crc(struct pblk *pblk)
 
 static void pblk_l2p_free(struct pblk *pblk)
 {
+#ifndef PBLK_DISABLE_DFTL
 	pblk_trans_free(pblk);
-#ifdef PBLK_DISABLE_D_FTL
+#else
 	vfree(pblk->trans_map);
 #endif
 }

--- a/drivers/lightnvm/pblk-init.c
+++ b/drivers/lightnvm/pblk-init.c
@@ -102,7 +102,7 @@ static void pblk_l2p_free(struct pblk *pblk)
 {
 	pblk_trans_free(pblk);
 #ifdef PBLK_DISABLE_D_FTL
-	lfree(pblk->trans_map);
+	vfree(pblk->trans_map);
 #endif
 }
 

--- a/drivers/lightnvm/pblk-init.c
+++ b/drivers/lightnvm/pblk-init.c
@@ -102,7 +102,7 @@ static void pblk_l2p_free(struct pblk *pblk)
 {
 	pblk_trans_free(pblk);
 #ifdef PBLK_DISABLE_D_FTL
-	vfree(pblk->trans_map);
+	lfree(pblk->trans_map);
 #endif
 }
 

--- a/drivers/lightnvm/pblk-recovery.c
+++ b/drivers/lightnvm/pblk-recovery.c
@@ -141,6 +141,7 @@ static int pblk_recov_l2p_from_emeta(struct pblk *pblk, struct pblk_line *line)
 	data_end = line->emeta_ssec;
 	nr_valid_lbas = le64_to_cpu(emeta_buf->nr_valid_lbas);
 
+	// data's first address to last address
 	for (i = data_start; i < data_end; i++) {
 		struct ppa_addr ppa;
 		int pos;
@@ -898,7 +899,9 @@ struct pblk_line *pblk_recov_l2p(struct pblk *pblk)
 	/* Scan recovery - takes place when FTL snapshot fails */
 	spin_lock(&l_mg->free_lock);
 	meta_line = find_first_zero_bit(&l_mg->meta_bitmap, PBLK_DATA_LINES);
+	// Gijun: Why do this? I can't understand...
 	set_bit(meta_line, &l_mg->meta_bitmap);
+	// Gijun: just get pointer. sline_meta doesn't have any value.
 	smeta = l_mg->sline_meta[meta_line];
 	emeta = l_mg->eline_meta[meta_line];
 	smeta_buf = (struct line_smeta *)smeta;

--- a/drivers/lightnvm/pblk-recovery.c
+++ b/drivers/lightnvm/pblk-recovery.c
@@ -141,7 +141,6 @@ static int pblk_recov_l2p_from_emeta(struct pblk *pblk, struct pblk_line *line)
 	data_end = line->emeta_ssec;
 	nr_valid_lbas = le64_to_cpu(emeta_buf->nr_valid_lbas);
 
-	// data's first address to last address
 	for (i = data_start; i < data_end; i++) {
 		struct ppa_addr ppa;
 		int pos;
@@ -899,9 +898,7 @@ struct pblk_line *pblk_recov_l2p(struct pblk *pblk)
 	/* Scan recovery - takes place when FTL snapshot fails */
 	spin_lock(&l_mg->free_lock);
 	meta_line = find_first_zero_bit(&l_mg->meta_bitmap, PBLK_DATA_LINES);
-	// Gijun: Why do this? I can't understand...
 	set_bit(meta_line, &l_mg->meta_bitmap);
-	// Gijun: just get pointer. sline_meta doesn't have any value.
 	smeta = l_mg->sline_meta[meta_line];
 	emeta = l_mg->eline_meta[meta_line];
 	smeta_buf = (struct line_smeta *)smeta;

--- a/drivers/lightnvm/pblk-trans.c
+++ b/drivers/lightnvm/pblk-trans.c
@@ -22,29 +22,38 @@ static int pblk_trans_recov_from_mem(struct pblk *pblk)
 	struct nvm_geo *geo = &dev->geo;
 	struct pblk_line_meta *lm = &pblk->lm;
 	struct pblk_trans_dir *dir = &pblk->dir;
-	const size_t map_size = pblk_trans_map_size(pblk);
+
 	int chk_num = 0, line_id = 0;
-	size_t addr = 0;
+	sector_t addr = 0, entry_size = 0;
 
 	/**
 	 * Save the trans map to device.
 	 * TODO: if snapshot exists then this will be skipped.
 	 */
-	for(addr = 0; addr < map_size; addr += geo->clba) {
+
+	if (pblk->addrf_len < 32) {
+		entry_size = 4;
+	} else {
+		entry_size = 8;
+	}
+
+	for(addr = 0; addr <= pblk->rl.nr_secs; addr += geo->clba) {
 		struct pblk_trans_entry *now = &dir->entry[chk_num];
 		int tmp_chk_num = 0;
 
 		now->hot_ratio = -1;
 		now->line_id = line_id;
-		now->cache_ptr = pblk->trans_map + addr;
+		now->cache_ptr = pblk->trans_map + addr * entry_size;
+		now->chk_num = chk_num;
 
-		tmp_chk_num = now->chk_num = chk_num;
+		now->chk_size = geo->clba;
 
-		if(!dir->op->write(pblk, now))
+		if(dir->op->write(pblk, now))
 			return -EINVAL;
+
 		/* TODO: Below comment deletion is enabled only when you finish to test read and write about global translation directory*/
 		// now->cache_ptr = NULL; 
-		chk_num += 1;
+		tmp_chk_num = chk_num += 1;
 		if (do_div(tmp_chk_num, lm->blk_per_line) == 0)
 			line_id += 1;
 	}
@@ -52,6 +61,7 @@ static int pblk_trans_recov_from_mem(struct pblk *pblk)
 #ifndef PBLK_TRANS_MEM_TABLE
 	vfree(pblk->trans_map);
 #endif
+	return 0;
 }
 
 #ifdef PBLK_TRANS_MEM_TABLE
@@ -70,6 +80,24 @@ static struct pblk_trans_op trans_op = {
 	.write = memory_l2p_write,
 };
 #endif
+
+static void pblk_trans_print_entry_table(struct pblk *pblk)
+{
+	struct pblk_trans_dir *dir = &pblk->dir;
+	size_t entry_num = dir->entry_num;
+	int index = 0;
+
+	trace_printk("hot_ratio/line_id/chk_num/chk_size/cache_ptr\n");
+	for (index = 0; index < entry_num; index++){
+		struct pblk_trans_entry *entry = &dir->entry[index];
+		trace_printk("%d, %d, %d, %u, %p\n",
+				entry->hot_ratio,
+				entry->line_id,
+				entry->chk_num,
+				entry->chk_size,
+				entry->cache_ptr);
+	}
+}
 
 int pblk_trans_init(struct pblk *pblk)
 {
@@ -99,16 +127,19 @@ int pblk_trans_init(struct pblk *pblk)
 	}
 
 	/* sequential memory allocated */
-	dir->entry = kzalloc(nr_chks*dir_entry_size, GFP_KERNEL);
+	dir->entry_num = nr_chks;
+	dir->entry = kzalloc(dir->entry_num*dir_entry_size, GFP_KERNEL);
 	if (!dir->entry)
 		return -ENOMEM;
 	dir->op = &trans_op;
 	INIT_LIST_HEAD(&(dir->free_list));
 
-	/* @TODO: You must binding the operation to this part */
+	/* original l2p table entry mapping */
+	pblk_trans_recov_from_mem(pblk);
+	dir->enable = 1;
 
-	trace_printk("cache size: %d\tentry size: %d\n",
-			(geo->clba * PBLK_TRANS_CACHE_SIZE), (nr_chks*dir_entry_size));
+	/* DEBUG FUNCTION! THIS WILL BE ERASED */ 
+	pblk_trans_print_entry_table(pblk);
 
 	return 0;
 }
@@ -121,61 +152,42 @@ static void pblk_trans_entry_update (struct pblk_trans_entry *entry)
 static struct ppa_addr pblk_trans_ppa_get (struct pblk *pblk, 
 		sector_t lba)
 {
-	struct nvm_tgt_dev *dev = pblk->dev;
-	struct nvm_geo *geo = &dev->geo;
-
 	struct pblk_trans_dir *dir = &pblk->dir;
 
 	sector_t base = lba;
-	sector_t offset = do_div(base, geo->clba);
+	sector_t offset; 
 	struct ppa_addr ppa;
+	void *ptr;
 
-	void *cache_ptr = dir->entry[base].cache_ptr;
-
+	offset = do_div(base, dir->entry[0].chk_size);
 	ppa.ppa = 0;
+	ptr = dir->entry[base].cache_ptr;
 
-	if (cache_ptr == NULL) /* cache miss */
+	if (ptr == NULL) /* cache miss */
 		return ppa;
 
-	/**
-	 * blk means that part of the cached mapping table.
-	 * Assume that our memory consists like below
-	 *
-	 * 0x3000 1 ==> global entry index 1 cache_ptr
-	 * 0x3008 2
-	 * 0x3010 3
-	 * 0x3018 6 ==> global entry index 2 cache_ptr
-	 * 0x3020 7
-	 * 0x3038 8
-	 *
-	 * In this situation, if lba is 2 then we refer
-	 * the cache_ptr 0x3000 else lba is 8 then we refer
-	 * the cache_ptr 0x3018.
-	 *
-	 * This is the start position of l2p table chunk
-	 * start point.
-	 */
-	if (pblk->addrf_len < 32) { // OCSSD 1.2 specification
-		u32 *chk = (u32 *)cache_ptr;
+	if (pblk->addrf_len < 32) {
+		u32 *chk = (u32 *)ptr;
 
 		ppa = pblk_ppa32_to_ppa64(pblk, chk[offset]);
-	} else { // OCSSD 2.0 specification
-		struct ppa_addr *chk = (struct ppa_addr *)cache_ptr;
+	} else {
+		struct ppa_addr *chk = (struct ppa_addr *)ptr;
 
 		ppa = chk[offset];
 	}
 	pblk_trans_entry_update(&dir->entry[base]);
 
+	trace_printk(" <<< cache_ptr: %p, lba: %lu, ppa: %llu, base: %lu, offset: %lu\n",ptr ,lba ,ppa.ppa, base, offset);
 	return ppa;
 }
 
 struct ppa_addr pblk_trans_l2p_map_get(struct pblk *pblk, sector_t lba)
 {
-	struct ppa_addr ppa = pblk_trans_l2p_map_get(pblk, lba);
+	struct ppa_addr ppa = pblk_trans_ppa_get(pblk, lba);
 
 	if (!ppa.ppa) { /* cache miss*/
+		trace_printk("cache miss!!\n");
 	}
-
 	return ppa;
 }
 

--- a/drivers/lightnvm/pblk-trans.c
+++ b/drivers/lightnvm/pblk-trans.c
@@ -1,0 +1,150 @@
+/*
+ * Copyright (C) 2019 OSLAB
+ * Initial release: Gijun O <kijunking@pusan.ac.kr>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License version
+ * 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ * 
+ * pblk-trans.c - pblk's global translation directory and cached mapping table
+ */
+
+#include "pblk.h"
+
+#ifdef PBLK_TRANS_MEM_TABLE
+static int memory_l2p_read(struct pblk *pblk)
+{
+	return 0;
+}
+
+static int memory_l2p_write(struct pblk *pblk)
+{
+	return 0;
+}
+
+static struct pblk_trans_op trans_op = {
+	.read = memory_l2p_read,
+	.write = memory_l2p_write,
+};
+#endif
+
+int pblk_trans_init(struct pblk *pblk)
+{
+	struct nvm_tgt_dev *dev = pblk->dev;
+	struct nvm_geo *geo = &dev->geo;
+
+	struct pblk_trans_cache *cache = &pblk->cache;
+	struct pblk_trans_dir *dir = &pblk->dir;
+
+	struct pblk_line_meta *lm = &pblk->lm;
+	struct pblk_line_mgmt *l_mg = &pblk->l_mg;
+
+	unsigned int nr_chks = lm->blk_per_line * l_mg->nr_lines;
+	unsigned int entry_size = sizeof(struct pblk_trans_entry);
+
+	/* clba means chunk size*/
+	cache->trans_map = vmalloc(geo->clba * PBLK_TRANS_CACHE_SIZE); 
+	if (!cache->trans_map)
+		return -ENOMEM;
+	atomic64_set(&cache->usage, 0);
+
+
+	dir->entry = kzalloc(nr_chks*entry_size, GFP_KERNEL);
+	if (!dir->entry)
+		return -ENOMEM;
+	atomic64_set(&dir->usage, 0);
+	dir->op = &trans_op;
+	INIT_LIST_HEAD(&(dir->free_list));
+
+	/* @TODO: You must binding the operation to this part */
+
+	trace_printk("cache size: %d\tentry size: %d\n",
+			(geo->clba * PBLK_TRANS_CACHE_SIZE), (nr_chks*entry_size));
+
+	return 0;
+}
+
+static void pblk_trans_entry_update (struct pblk_trans_entry *entry)
+{
+	entry->hot_ratio += 1;
+}
+
+static struct ppa_addr pblk_trans_ppa_get (struct pblk *pblk, 
+		sector_t lba)
+{
+	struct nvm_tgt_dev *dev = pblk->dev;
+	struct nvm_geo *geo = &dev->geo;
+
+	struct pblk_trans_dir *dir = &pblk->dir;
+
+	sector_t base = lba;
+	sector_t offset = do_div(base, geo->clba);
+	struct ppa_addr ppa;
+
+	void *cache_ptr = dir->entry[base].cache_ptr;
+
+	ppa.ppa = 0;
+
+	if (cache_ptr == NULL) /* cache miss */
+		return ppa;
+
+	/**
+	 * blk means that part of the cached mapping table.
+	 * Assume that our memory consists like below
+	 *
+	 * 0x3000 1 ==> global entry index 1 cache_ptr
+	 * 0x3008 2
+	 * 0x3010 3
+	 * 0x3018 6 ==> global entry index 2 cache_ptr
+	 * 0x3020 7
+	 * 0x3038 8
+	 *
+	 * In this situation, if lba is 2 then we refer
+	 * the cache_ptr 0x3000 else lba is 8 then we refer
+	 * the cache_ptr 0x3018.
+	 *
+	 * This is the start position of l2p table chunk
+	 * start point.
+	 */
+	if (pblk->addrf_len < 32) { // OCSSD 1.2 specification
+		u32 *chk = (u32 *)cache_ptr;
+
+		ppa = pblk_ppa32_to_ppa64(pblk, chk[offset]);
+	} else { // OCSSD 2.0 specification
+		struct ppa_addr *chk = (struct ppa_addr *)cache_ptr;
+
+		ppa = chk[offset];
+	}
+	pblk_trans_entry_update(&dir->entry[base]);
+
+	return ppa;
+}
+
+struct ppa_addr pblk_trans_l2p_map_get(struct pblk *pblk, sector_t lba)
+{
+	struct ppa_addr ppa = pblk_trans_l2p_map_get(pblk, lba);
+
+	if (!ppa.ppa) { /* cache miss*/
+	}
+
+	return ppa;
+}
+
+void pblk_trans_l2p_map_set(struct pblk *pblk, sector_t lba, struct ppa_addr ppa)
+{
+}
+
+void pblk_trans_free(struct pblk *pblk)
+{
+	struct pblk_trans_cache *cache = &pblk->cache;
+	struct pblk_trans_dir *dir = &pblk->dir;
+
+	vfree(cache->trans_map);
+	kfree(dir->entry);
+}
+

--- a/drivers/lightnvm/pblk-trans.c
+++ b/drivers/lightnvm/pblk-trans.c
@@ -89,20 +89,8 @@ static int pblk_trans_recov_from_mem(struct pblk *pblk)
 static void pblk_trans_mem_copy(struct pblk* pblk,
 		unsigned char *dst, unsigned char *src, size_t size)
 {
-	size_t i;
-	if (pblk->addrf_len < 32) {
-		u32 *chk_dst = (u32 *)dst;
-		u32 *chk_src = (u32 *)src;
-		for(i = 0; i < size; i++) {
-			chk_dst[i] = chk_src[i];
-		}
-	} else {
-		struct ppa_addr *chk_dst = (struct ppa_addr *)dst;
-		struct ppa_addr *chk_src = (struct ppa_addr *)src;
-		for(i = 0; i < size; i++) {
-			chk_dst[i] = chk_src[i];
-		}
-	}
+	size_t entry_size = pblk_trans_entry_size_get(pblk);
+	memcpy(dst, src, size * entry_size);
 }
 
 

--- a/drivers/lightnvm/pblk.h
+++ b/drivers/lightnvm/pblk.h
@@ -609,7 +609,7 @@ struct pblk_trans_dir {
 	int enable; /* Initial recovery successful then this is true */
 	struct pblk_trans_entry *entry;
 	struct pblk_trans_op *op;
-	struct list_head free_list;
+	spinlock_t lock;
 };
 
 struct pblk {
@@ -953,7 +953,7 @@ int pblk_rl_is_limit(struct pblk_rl *rl);
  */
 int pblk_trans_init(struct pblk *pblk);
 struct ppa_addr pblk_trans_l2p_map_get (struct pblk *pblk, sector_t lba);
-void pblk_trans_l2p_map_set(struct pblk *pblk, sector_t lba, struct ppa_addr ppa);
+int pblk_trans_l2p_map_set(struct pblk *pblk, sector_t lba, struct ppa_addr ppa);
 void pblk_trans_free(struct pblk *pblk);
 size_t pblk_trans_map_size(struct pblk *pblk);
 /*
@@ -1207,14 +1207,12 @@ static inline struct ppa_addr pblk_trans_map_get(struct pblk *pblk,
 static inline void pblk_trans_map_set(struct pblk *pblk, sector_t lba,
 						struct ppa_addr ppa)
 {
-/*
 #ifndef PBLK_DISABLE_D_FTL
 	if (pblk->dir.enable) {
 		pblk_trans_l2p_map_set(pblk, lba, ppa);
 		return ;
 	}
 #endif
-*/
 
 	if (pblk->addrf_len < 32) {
 		u32 *map = (u32 *)pblk->trans_map;

--- a/drivers/lightnvm/pblk.h
+++ b/drivers/lightnvm/pblk.h
@@ -585,6 +585,7 @@ struct pblk_trans_cache {
 	unsigned char *trans_map; /* compatible type of the mapping table */
 	                          /* (u64 or u32 casting is necessary!) */
 	unsigned char *bucket; /* It is a kind of write buffer */
+	unsigned long *free_bitmap;
 };
 
 struct pblk_trans_entry {
@@ -592,12 +593,9 @@ struct pblk_trans_entry {
 	int line_id;
 	int chk_num;
 	/* When you use the size then you have to multiply 'entry_size' */
-	u32 chk_size; /* The number of the lba. NOT REAL MEMORY ALLOCATION SIZE */
+	size_t chk_size; /* The number of the lba. NOT REAL MEMORY ALLOCATION SIZE */
 
 	void *cache_ptr; /* start location of cache */
-
-	atomic_t free_ready; /* if true then this cannot be selected as victim */
-	struct list_head list;
 };
 
 struct pblk_trans_op {

--- a/drivers/lightnvm/pblk.h
+++ b/drivers/lightnvm/pblk.h
@@ -590,7 +590,7 @@ struct pblk_trans_entry {
 	int hot_ratio;
 	int line_id;
 	int chk_num;
-	size_t chk_size;
+	u32 chk_size;
 
 	void *cache_ptr; /* start location of cache */
 
@@ -605,6 +605,7 @@ struct pblk_trans_op {
 };
 
 struct pblk_trans_dir {
+	size_t entry_num;
 	int enable; /* Initial recovery successful then this is true */
 	struct pblk_trans_entry *entry;
 	struct pblk_trans_op *op;
@@ -1206,12 +1207,14 @@ static inline struct ppa_addr pblk_trans_map_get(struct pblk *pblk,
 static inline void pblk_trans_map_set(struct pblk *pblk, sector_t lba,
 						struct ppa_addr ppa)
 {
+/*
 #ifndef PBLK_DISABLE_D_FTL
 	if (pblk->dir.enable) {
 		pblk_trans_l2p_map_set(pblk, lba, ppa);
 		return ;
 	}
 #endif
+*/
 
 	if (pblk->addrf_len < 32) {
 		u32 *map = (u32 *)pblk->trans_map;

--- a/drivers/lightnvm/pblk.h
+++ b/drivers/lightnvm/pblk.h
@@ -59,7 +59,7 @@
 #define PBLK_DEFAULT_OP (11)
 
 /* D-FTL setting */
-#define PBLK_TRANS_CACHE_SIZE (20) /* Cache size */
+#define PBLK_TRANS_CACHE_SIZE (40) /* Cache size */
 #define PBLK_TRANS_MEM_TABLE ;     /* Use memory l2p table */
 
 enum {
@@ -595,7 +595,7 @@ struct pblk_trans_entry {
 	/* When you use the size then you have to multiply 'entry_size' */
 	size_t chk_size; /* The number of the lba. NOT REAL MEMORY ALLOCATION SIZE */
 	unsigned long bit_idx;
-	void *cache_ptr; /* start location of cache */
+	unsigned char*cache_ptr; /* start location of cache */
 };
 
 struct pblk_trans_op {

--- a/drivers/lightnvm/pblk.h
+++ b/drivers/lightnvm/pblk.h
@@ -595,7 +595,7 @@ struct pblk_trans_entry {
 	/* When you use the size then you have to multiply 'entry_size' */
 	size_t chk_size; /* The number of the lba. NOT REAL MEMORY ALLOCATION SIZE */
 	unsigned long bit_idx;
-	unsigned char*cache_ptr; /* start location of cache */
+	unsigned char *cache_ptr; /* start location of cache */
 };
 
 struct pblk_trans_op {

--- a/drivers/lightnvm/pblk.h
+++ b/drivers/lightnvm/pblk.h
@@ -594,7 +594,7 @@ struct pblk_trans_entry {
 	int chk_num;
 	/* When you use the size then you have to multiply 'entry_size' */
 	size_t chk_size; /* The number of the lba. NOT REAL MEMORY ALLOCATION SIZE */
-
+	unsigned long bit_idx;
 	void *cache_ptr; /* start location of cache */
 };
 

--- a/drivers/lightnvm/pblk.h
+++ b/drivers/lightnvm/pblk.h
@@ -573,6 +573,27 @@ struct pblk_addrf {
 	int sec_ws_stripe;
 };
 
+struct pblk_trans_cache {
+	atomic64_t usage;
+	unsigned char *trans_map; /* lba-ppa memory cache */
+};
+
+struct pblk_trans_entry {
+	int hot_ratio;
+	int line_num;
+	int chk_num;
+
+	void *cache_ptr; /* start location of cache */
+
+	atomic_t free_ready; /* if true then this cannot be selected as victim */
+	struct list_head free_list;
+};
+
+struct pblk_trans_dir {
+	atomic64_t usage;
+	struct pblk_trans_entry *entry;
+};
+
 struct pblk {
 	struct nvm_tgt_dev *dev;
 	struct gendisk *disk;
@@ -700,27 +721,6 @@ struct pblk_line_ws {
 	struct pblk_line *line;
 	void *priv;
 	struct work_struct ws;
-};
-
-struct pblk_trans_cache {
-	atomic64_t usage;
-	unsigned char *trans_map; /* lba-ppa memory cache */
-};
-
-struct pblk_trans_entry {
-	int hot_ratio;
-	int line_num;
-	int chk_num;
-
-	void *cache_ptr; /* start location of cache */
-
-	atomic_t free_ready; /* if true then this cannot be selected as victim */
-	struct list_head free_list;
-};
-
-struct pblk_trans_dir {
-	atomic64_t usage;
-	struct pblk_trans_entry *entry;
 };
 
 #define pblk_g_rq_size (sizeof(struct nvm_rq) + sizeof(struct pblk_g_ctx))

--- a/drivers/lightnvm/pblk.h
+++ b/drivers/lightnvm/pblk.h
@@ -580,7 +580,8 @@ struct pblk_addrf {
 };
 
 struct pblk_trans_cache {
-	size_t size;
+	/* When you use the size then you have to multiply 'entry_size' */
+	size_t size; /* The number of the lba. NOT REAL MEMORY ALLOCATION SIZE */
 	unsigned char *trans_map; /* compatible type of the mapping table */
 	                          /* (u64 or u32 casting is necessary!) */
 	unsigned char *bucket; /* It is a kind of write buffer */
@@ -590,7 +591,8 @@ struct pblk_trans_entry {
 	int hot_ratio;
 	int line_id;
 	int chk_num;
-	u32 chk_size;
+	/* When you use the size then you have to multiply 'entry_size' */
+	u32 chk_size; /* The number of the lba. NOT REAL MEMORY ALLOCATION SIZE */
 
 	void *cache_ptr; /* start location of cache */
 


### PR DESCRIPTION
D-FTL의 핵심적인 요소인 Global Translation Directory를 개발 완료하였습니다.
주요 구조체로는 아래와 같은 구조체를 가집니다.

![주요 구조체](https://github.com/central-engineering-organization/final-term-diagram/blob/master/GTB-struct.jpg?raw=true)

여기서 `pblk_trans_cache`는 D-FTL에서 Cached Mapping Table의 역할을 하는 것에 해당하고, `pblk_trans_dir`은 Global Translation Directory에 해당하고 이것이 포함하는 `pblk_trans_entry`와 `pblk_trans_op`는 각각 directory의 행 구성과 inteface가 될 연산자를 지칭합니다.

`pblk_trans_entry` 안에서 `chk_size`는 chunk에 들어가는 *lba-ppa 쌍의 갯수를 의미*합니다. chunk의 크기(`geo->clba`로 가져오는 값)를 의미하지 않음을 유의해야 합니다. `bit_idx`의 경우 cache의 free_bitmap에서 현재 entry가 점유하는 bit의 위치에 대한 정보를 가지는 것에 해당합니다.

그리고 외부로 노출되는 함수는 아래와 같고, 여기서 `pblk_trans_l2p_map_set`과 `pblk_trans_l2p_map_get`은 `pblk_trans_map_set`, `pblk_trans_map_get` 안에서 D-FTL의 동작을 직접적으로 수행하는 것에 해당합니다.

```c
int pblk_trans_init(struct pblk *pblk);
struct ppa_addr pblk_trans_l2p_map_get (struct pblk *pblk, sector_t lba);
int pblk_trans_l2p_map_set(struct pblk *pblk, sector_t lba, struct ppa_addr ppa);
void pblk_trans_free(struct pblk *pblk);
size_t pblk_trans_map_size(struct pblk *pblk);
```

세부적인 프로그램의 동작은 아래와 같다고 할 수 있습니다.
![implementation](https://github.com/central-engineering-organization/final-term-diagram/blob/master/GTB-flow.jpg?raw=true)
