### PR TITLE
Memory based global translation test fixed

### DIFF
--- a/drivers/lightnvm/pblk-init.c
+++ b/drivers/lightnvm/pblk-init.c
@@ -148,6 +148,24 @@ static int pblk_l2p_init(struct pblk *pblk, bool factory_init)
 	size_t map_size;
 
 	map_size = pblk_trans_map_size(pblk);
+
+#ifndef PBLK_DISABLE_D_FTL
+	{
+		size_t remain, quotient = map_size;
+		size_t calib_ratio = PBLK_TRANS_CALIB_RATIO;
+
+		remain = do_div(quotient, PBLK_TRANS_CHUNK_SIZE);
+		/***
+		 * DO NOT REMOVE THE `calib_ratio`!!
+		 * I don't know why this is necessary.
+		 *
+		 * Unfortunately, if it doesn't exist
+		 * then kernel occurs kernel panic.
+		 */
+		map_size = map_size + remain*calib_ratio;
+	}
+#endif
+
 	pblk->trans_map = vmalloc(map_size);
 	if (!pblk->trans_map)
 		return -ENOMEM;

--- a/drivers/lightnvm/pblk.h
+++ b/drivers/lightnvm/pblk.h
@@ -59,7 +59,14 @@
 #define PBLK_DEFAULT_OP (11)
 
 /* D-FTL setting */
-#define PBLK_TRANS_CACHE_SIZE (40) /* Cache size */
+//#define PBLK_DISABLE_D_FTL ;
+#define DEFAULT_CHUNK_SIZE \
+	(pblk->dev->geo.clba * pblk->dev->geo.csecs)
+#define USER_DEFINED_CHUNK_SIZE	(pblk->dev->geo.csecs)
+
+#define PBLK_TRANS_CALIB_RATIO (2) /* For trans_map alloc */ 
+#define PBLK_TRANS_CHUNK_SIZE (DEFAULT_CHUNK_SIZE)
+#define PBLK_TRANS_CACHE_SIZE (2) /* Cache size */
 #define PBLK_TRANS_MEM_TABLE ;     /* Use memory l2p table */
 
 enum {


### PR DESCRIPTION
The previous version has a critical error.
When you make the l2p size under 16MB which means chunk size,
it occurs `memcpy` error.

That's because I am not considering the original l2p table.
So, I fix that problem. The specific change list is below.

- pblk-init.c: I adjusted the value which determines the original l2p table size to fit the chunk size.
- pblk-trans.c:
    All `kmalloc` changed to `vmalloc`.
    Because of the `kmalloc` has a limit to allocate the memory
    but `vmalloc` hasn't a limit.

    And changed the cached mapping table location.
    This made the memory more efficiently to allocate
    (original l2p table deallocate before cached mapping table allocate).

    Lastly, I changed the directory allocation formula.
- pblk.h: Added some macro and made a more robust macro.