### PR TITLE
Refer to ppa_addr problem HOT FIX

### DIFF
--- a/drivers/lightnvm/pblk.h
+++ b/drivers/lightnvm/pblk.h
@@ -64,7 +64,6 @@
 	(pblk->dev->geo.clba * pblk->dev->geo.csecs)
 #define USER_DEFINED_CHUNK_SIZE	(pblk->dev->geo.csecs)
 
-#define PBLK_TRANS_CALIB_RATIO (2) /* For trans_map alloc */ 
 #define PBLK_TRANS_CHUNK_SIZE (DEFAULT_CHUNK_SIZE)
 #define PBLK_TRANS_CACHE_SIZE (2) /* Cache size */
 #define PBLK_TRANS_MEM_TABLE ;     /* Use memory l2p table */


### PR DESCRIPTION
Previous version cache hit and miss find to check the `ppa_addr` value which is 0.
Unfortunately, `ppa_addr` can enable to have a `ppa_addr` = 0.
This makes we cannot use the `ppa_addr` 0 position.

So, I changed the 0 to `ADDR_EMPTY`. But this can make the critical
logical error in `pblk_trans_l2p_get` function due to the incorrect
cache hit logic. So, I changed the original logic to valid logic
which used `pblk_trans_cache_hit`.