### PR TITLE
Make a function which supports the R/W to OCSSD

### DIFF
--- a/drivers/lightnvm/pblk-init.c
+++ b/drivers/lightnvm/pblk-init.c
@@ -847,6 +847,7 @@ static int pblk_line_mg_init(struct pblk *pblk)
 
 	l_mg->nr_lines = geo->num_chk;
 	l_mg->log_line = l_mg->data_line = NULL;
+	l_mg->trans_line = NULL;
 	l_mg->l_seq_nr = l_mg->d_seq_nr = 0;
 	l_mg->nr_free_lines = 0;
 	bitmap_zero(&l_mg->meta_bitmap, PBLK_DATA_LINES);

--- a/drivers/lightnvm/pblk-trans.c
+++ b/drivers/lightnvm/pblk-trans.c
@@ -111,12 +111,14 @@ static int memory_l2p_write(struct pblk *pblk, struct pblk_trans_entry *entry)
 {
 	sector_t offset = 0; 
 	void *map_ptr = NULL; 
+	struct pblk_line_mgmt *l_mg = &pblk->l_mg;
 
 	/* only used in memory simulator. DON'T USE IN SSD */
 	static int memory_index = 0;
 	int index = entry->chk_num;
 	/* only used in memory simulator. DON'T USE IN SSD */
 
+	trace_printk("trans line id: %u\n", l_mg->trans_line->id);
 	if (entry->cache_ptr == NULL)
 		return -EINVAL;
 
@@ -152,8 +154,15 @@ int pblk_trans_init(struct pblk *pblk)
 {
 	struct pblk_trans_cache *cache = &pblk->cache;
 	struct pblk_trans_dir *dir = &pblk->dir;
+	struct pblk_line_mgmt *l_mg = &pblk->l_mg;
 
 	unsigned int dir_entry_size = sizeof(struct pblk_trans_entry);
+
+	struct pblk_line *line = pblk_line_get_first_trans(pblk);
+	trace_printk("trans line id: %u\n", l_mg->trans_line->id);
+	trace_printk("local line id: %u\n", line->id);
+	trace_printk("line_type: %d\n", line->type);
+	trace_printk("blk_in_line: %d\n", atomic_read(&line->blk_in_line));
 
 	dir->entry_num = pblk_trans_map_size(pblk);
 	do_div(dir->entry_num, PBLK_TRANS_CHUNK_SIZE);

--- a/drivers/lightnvm/pblk.h
+++ b/drivers/lightnvm/pblk.h
@@ -67,6 +67,7 @@
 #define PBLK_TRANS_CHUNK_SIZE (DEFAULT_CHUNK_SIZE)
 #define PBLK_TRANS_CACHE_SIZE (2) /* Cache size */
 #define PBLK_TRANS_MEM_TABLE ;     /* Use memory l2p table */
+#define PBLK_TRANS_SSD_TABLE ;
 
 enum {
 	PBLK_READ		= READ,
@@ -602,6 +603,7 @@ struct pblk_trans_entry {
 	int hot_ratio;
 	int line_id;
 	int chk_num;
+	u64 paddr; /* TODO: this must be changed to chk_num!!! */
 	/* When you use the size then you have to multiply 'entry_size' */
 	size_t chk_size; /* The number of the lba. NOT REAL MEMORY ALLOCATION SIZE */
 	unsigned long bit_idx;

--- a/drivers/lightnvm/pblk.h
+++ b/drivers/lightnvm/pblk.h
@@ -307,6 +307,7 @@ enum {
 	PBLK_LINETYPE_FREE = 0,
 	PBLK_LINETYPE_LOG = 1,
 	PBLK_LINETYPE_DATA = 2,
+	PBLK_LINETYPE_TRANS = 4,
 
 	/* Line state */
 	PBLK_LINESTATE_NEW = 9,
@@ -506,8 +507,10 @@ struct pblk_line_mgmt {
 
 	struct pblk_line *log_line;	/* Current FTL log line */
 	struct pblk_line *data_line;	/* Current data line */
+	struct pblk_line *trans_line; /* Current Trans Line */
 	struct pblk_line *log_next;	/* Next FTL log line */
 	struct pblk_line *data_next;	/* Next data line */
+	struct pblk_line *trans_next; /*Next trans line*/
 
 	struct list_head emeta_list;	/* Lines queued to schedule emeta */
 
@@ -527,6 +530,7 @@ struct pblk_line_mgmt {
 
 	unsigned long d_seq_nr;		/* Data line unique sequence number */
 	unsigned long l_seq_nr;		/* Log line unique sequence number */
+	unsigned long t_seq_nr;     /* Trans line unique sequence number */
 
 	spinlock_t free_lock;
 	spinlock_t close_lock;
@@ -819,6 +823,7 @@ struct bio *pblk_bio_map_addr(struct pblk *pblk, void *data,
 			      int alloc_type, gfp_t gfp_mask);
 struct pblk_line *pblk_line_get(struct pblk *pblk);
 struct pblk_line *pblk_line_get_first_data(struct pblk *pblk);
+struct pblk_line *pblk_line_get_first_trans(struct pblk *pblk);
 struct pblk_line *pblk_line_replace_data(struct pblk *pblk);
 int pblk_line_recov_alloc(struct pblk *pblk, struct pblk_line *line);
 void pblk_line_recov_close(struct pblk *pblk, struct pblk_line *line);


### PR DESCRIPTION
First, I make the function names `pblk_line_get_first_trans`. It gets the first line for global translation directory. In the line, we can write the portion of l2p table.

Next, I make the function which names `pblk_line_submit_trans_io` to support the R/W to OCSSD. I referred to the `pblk_line_submit_emeta_io` to make this function. This function has two operations, read and write.

The most important thing is the data size. `pblk_line_submit_trans_io` always depends on the chunk size. In other words, it doesn't matter what your data size is.

Currently, this commit has sample R/W sequences in the `pblk_trans_init` function. If you want to check how to use the previous `pblk_line_submit_trans_io` function, then you check that lines.

Lastly, let me say one more word. This function doesn't have a garbage collection sequence. So, we have to make that sequence. If you want to make that sequence then, check the `TODO` in the `pblk-trans.c` file.